### PR TITLE
Multiple db strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metric-im/componentry",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Runtime framework for merging metric modules",
   "main": "index.mjs",
   "scripts": {},


### PR DESCRIPTION
allow mongo.host to be a structure with multiple database strings. If the value is a string, original functionality is the same, otherwise each entry is connected and named to the corresponding attribute:
```
{mongo:{host:{db:"connection string",db2:"connection string}}}
// connector.db and connector.db2 will be db instances connected with the given string
```